### PR TITLE
Several updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ fn window_controls<C: ContainerExt>(container: &C) {
 }
 
 fn main_page(stack: &gtk::Stack) {
-    let page = settings_page(stack, "Desktop");
+    let page = settings_page(stack, "General");
 
     super_key(&page);
     hot_corner(&page);
@@ -481,7 +481,17 @@ fn workspaces_page(stack: &gtk::Stack) {
 
 impl PopDesktopWidget {
     pub fn new(stack: &gtk::Stack) -> Self {
+        let mut children = Vec::new();
+        stack.foreach(|w| {
+            let name = stack.get_child_name(w).unwrap();
+            let title = stack.get_child_title(w).unwrap();
+            stack.remove(w);
+            children.push((w.clone(), name, title));
+        });
         main_page(&stack);
+        for (w, name, title) in children {
+            stack.add_titled(&w, &name, &title);
+        }
         appearance_page(&stack);
         dock_page(&stack);
         workspaces_page(&stack);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,14 +368,11 @@ fn dock_size<C: ContainerExt>(container: &C) {
         radio_medium.join_group(Some(&radio_small));
         let radio_large = radio_row(&list_box, "Large (60px)", None);
         radio_large.join_group(Some(&radio_small));
-        let radio_custom = radio_row(&list_box, "Custom", None);
+        let radio_custom = gtk::RadioButton::new();
+        radio_custom.set_no_show_all(true);
         radio_custom.join_group(Some(&radio_small));
-
         let spin = spin_row(&list_box, "Custom Size", 8.0, 128.0, 1.0);
         settings.bind("dash-max-icon-size", &spin, "value", SettingsBindFlags::DEFAULT);
-        radio_custom.bind_property("active", &spin, "sensitive")
-            .flags(glib::BindingFlags::SYNC_CREATE)
-            .build();
 
         radio_bindings(&settings, "dash-max-icon-size", vec![
             (glib::Variant::from(36i32), radio_small),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate gtk_extras;
 
-use gio::{SettingsBindFlags, SettingsExt};
+use gio::{SettingsBindFlags, Settings, SettingsExt};
 use glib::clone;
 use gtk::prelude::*;
 use gtk_extras::settings;
@@ -427,9 +427,16 @@ fn dock_page(stack: &gtk::Stack) {
 fn workspaces_multi_monitor<C: ContainerExt>(container: &C) {
     let list_box = settings_list_box(container, "Multi-monitor Behavior");
 
-    let radio_span = radio_row(&list_box, "Workspaces Span Displays (TODO)", None);
-    let radio_separate = radio_row(&list_box, "Displays Have Separate Workspaces (TODO)", None);
-    radio_separate.join_group(Some(&radio_span));
+    let settings = Settings::new("org.gnome.mutter");
+
+    let radio_span = radio_row(&list_box, "Workspaces Span Displays", None);
+    let radio_primary = radio_row(&list_box, "Workspaces on Primary Display Only", None);
+    radio_primary.join_group(Some(&radio_span));
+
+    radio_bindings(&settings, "workspaces-only-on-primary", vec![
+        (glib::Variant::from(false), radio_span),
+        (glib::Variant::from(true), radio_primary),
+    ], None);
 }
 
 fn workspaces_position<C: ContainerExt>(container: &C) {


### PR DESCRIPTION
Updates the ordering in Gnome Control Center to place "Background" second, and rename "Desktop" to "General", as per current design:

![Screenshot from 2021-04-23 08-56-58](https://user-images.githubusercontent.com/2263150/115898201-23af7500-a412-11eb-89f9-edad8ade8acd.png)

Since the existing multi-monitor behavior setting is likely infeasible (https://github.com/pop-os/desktop-widget/issues/11), this changes it to match what Mutter supports (and makes it work):

![Screenshot from 2021-04-23 08-55-37](https://user-images.githubusercontent.com/2263150/115898200-23af7500-a412-11eb-8996-208277f62f08.png)

This also updates the "dock size" setting to address https://github.com/pop-os/desktop-widget/issues/8:

![Screenshot from 2021-04-23 08-52-35](https://user-images.githubusercontent.com/2263150/115898193-227e4800-a412-11eb-892b-7ac0a2ddf29f.png)
![Screenshot from 2021-04-23 08-52-51](https://user-images.githubusercontent.com/2263150/115898197-2316de80-a412-11eb-8902-f695c72c8a05.png)

