### PR TITLE
Various updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,6 +350,9 @@ fn dock_options<C: ContainerExt>(container: &C) {
 
         let switch = switch_row(&list_box, "Extend dock to the edges of the screen");
         settings.bind("extend-height", &switch, "active", SettingsBindFlags::DEFAULT);
+
+        let switch = switch_row(&list_box, "Show Mounted Volumes");
+        settings.bind("show-mounts", &switch, "active", SettingsBindFlags::DEFAULT);
     }
 
     switch_row(&list_box, "Show Launcher Icon in Dock (TODO)");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,17 +189,13 @@ fn super_key<C: ContainerExt>(container: &C) {
 }
 
 fn hot_corner<C: ContainerExt>(container: &C) {
-    let list_box = settings_list_box(container, "Hot Corner");
+    // TODO: Support more options in the future
 
-    let radio_disabled = radio_row(&list_box, "Disabled (TODO)", None);
-    let radio_workspaces = radio_row(&list_box, "Workspaces (TODO)", Some(
-        "Placing cursor in top-left corner opens the Window and Workspaces Overview"
-    ));
-    radio_workspaces.join_group(Some(&radio_disabled));
-    let radio_applications = radio_row(&list_box, "Applications (TODO)", Some(
-        "Placing cursor in top-left corner opens the Applications Overview"
-    ));
-    radio_applications.join_group(Some(&radio_disabled));
+    let list_box = settings_list_box(container, "Hot Corner");
+    let settings = gio::Settings::new("org.gnome.desktop.interface");
+
+    let switch = switch_row(&list_box, "Enable top-left hot corner for Workspaces");
+    settings.bind("enable-hot-corners", &switch, "active", SettingsBindFlags::DEFAULT);
 }
 
 fn top_bar<C: ContainerExt>(container: &C) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,10 +439,6 @@ fn workspaces_position<C: ContainerExt>(container: &C) {
     let radio_left = radio_row(&list_box, "Along the Left Side (TODO)", None);
     let radio_right = radio_row(&list_box, "Along the Right Side (TODO)", None);
     radio_right.join_group(Some(&radio_left));
-    let radio_top = radio_row(&list_box, "Top of the Screen (TODO)", None);
-    radio_top.join_group(Some(&radio_left));
-    let radio_bottom = radio_row(&list_box, "Bottom of the Screen (TODO)", None);
-    radio_bottom.join_group(Some(&radio_left));
 }
 
 fn workspaces_page(stack: &gtk::Stack) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,6 @@ fn top_bar<C: ContainerExt>(container: &C) {
         let combo = combo_row(&list_box, "Show Top Bar on Display", "Primary Display", &[
             "Primary Display",
             "All Displays",
-            "TODO"
         ]);
         let id = if settings.get_boolean("show-panel") {
             "All Displays"
@@ -334,7 +333,6 @@ fn dock_options<C: ContainerExt>(container: &C) {
         let combo = combo_row(&list_box, "Show Dock on Display", "Primary Display", &[
             "Primary Display",
             "All Displays",
-            "TODO"
         ]);
         let id = if settings.get_boolean("multi-monitor") {
             "All Displays"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,9 +351,72 @@ fn dock_options<C: ContainerExt>(container: &C) {
         settings.bind("show-mounts", &switch, "active", SettingsBindFlags::DEFAULT);
     }
 
-    switch_row(&list_box, "Show Launcher Icon in Dock (TODO)");
-    switch_row(&list_box, "Show Applications Icon in Dock (TODO)");
-    switch_row(&list_box, "Show Workspaces Icon in Dock (TODO)");
+    let shell_settings = gio::Settings::new("org.gnome.shell");
+    let launcher_switch = switch_row(&list_box, "Show Launcher Icon in Dock");
+    let workspaces_switch = switch_row(&list_box, "Show Workspaces Icon in Dock");
+    let applications_switch = switch_row(&list_box, "Show Applications Icon in Dock");
+    let update_switches = clone!(@strong shell_settings, @strong launcher_switch, @strong workspaces_switch, @strong applications_switch => move || {
+        let mut launcher_active = false;
+        let mut workspaces_active = false;
+        let mut applications_active = false;
+        for favorite in shell_settings.get_strv("favorite-apps") {
+            match favorite.as_str() {
+                "pop-cosmic-launcher.desktop" => launcher_active = true,
+                "pop-cosmic-workspaces.desktop" => workspaces_active = true,
+                "pop-cosmic-applications.desktop" => applications_active = true,
+                _ => {}
+            }
+        }
+        launcher_switch.set_active(launcher_active);
+        workspaces_switch.set_active(workspaces_active);
+        applications_switch.set_active(applications_active);
+    });
+    update_switches();
+    let handler_id = Rc::new(
+        shell_settings
+            .connect_local("changed::favorite-apps", false, move |_| {
+                update_switches();
+                None
+            })
+            .unwrap(),
+    );
+    let connect_switch = move |switch: &gtk::Switch, desktop, pos: usize| {
+        let shell_settings = shell_settings.clone();
+        let handler_id = handler_id.clone();
+        switch.connect_property_active_notify(move |switch| {
+            let active = switch.get_active();
+            let favorites = shell_settings.get_strv("favorite-apps");
+            let mut favorites = favorites.iter().map(|x| x.as_str()).collect::<Vec<_>>();
+            let index = favorites.iter().position(|x| *x == desktop);
+            if !active {
+                if let Some(index) = index {
+                    favorites.remove(index);
+                }
+            } else if index.is_none() {
+                // Insert at `pos`, or before first non-cosmic favorite
+                let pos = pos.min(
+                    favorites[..2]
+                        .iter()
+                        .position(|x| {
+                            ![
+                                "pop-cosmic-launcher.desktop",
+                                "pop-cosmic-workspaces.desktop",
+                                "pop-cosmic-applications.desktop",
+                            ]
+                            .contains(x)
+                        })
+                        .unwrap_or(2),
+                );
+                favorites.insert(pos, desktop);
+            }
+            shell_settings.block_signal(&handler_id);
+            shell_settings.set_strv("favorite-apps", &favorites).unwrap();
+            shell_settings.unblock_signal(&handler_id);
+        });
+    };
+    connect_switch(&launcher_switch, "pop-cosmic-launcher.desktop", 0);
+    connect_switch(&workspaces_switch, "pop-cosmic-workspaces.desktop", 1);
+    connect_switch(&applications_switch, "pop-cosmic-applications.desktop", 2);
 }
 
 fn dock_size<C: ContainerExt>(container: &C) {


### PR DESCRIPTION
* Remove `TODO` rows from dropdowns
* Add toggles for showing mounted drives in dock
* Allow setting autohide or intellihide for dock (or showing it all the time)
* Toggle for disabling hot corner instead of multiple options, for now
* Remove "Top of Screen" and "Bottom of Screen" options for workspace picker (still need to be implemented)

Further explanation of each change in commit messages.