### PR TITLE
Update dock options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -514,8 +514,9 @@ fn dock_page(stack: &gtk::Stack) {
     };
     page.add(&list_box);
 
+    let switch = switch_row(&list_box, "Enable Dock");
+
     if let Some(settings) = settings::new_checked("org.gnome.shell.extensions.dash-to-dock") {
-        let switch = switch_row(&list_box, "Enable Dock");
         settings.bind("manualhide", &switch, "active", SettingsBindFlags::DEFAULT | SettingsBindFlags::INVERT_BOOLEAN);
     }
 
@@ -523,6 +524,13 @@ fn dock_page(stack: &gtk::Stack) {
     dock_visibility(&page);
     dock_size(&page);
     dock_position(&page);
+
+
+    page.foreach(|child| {
+        if child != list_box.upcast_ref::<gtk::Widget>() {
+            switch.bind_property("active", child, "sensitive").build();
+        }
+    });
 }
 
 fn workspaces_multi_monitor<C: ContainerExt>(container: &C) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,7 @@ fn dock_page(stack: &gtk::Stack) {
     page.add(&list_box);
 
     if let Some(settings) = settings::new_checked("org.gnome.shell.extensions.dash-to-dock") {
-        let switch = switch_row(&list_box, "Show Dock");
+        let switch = switch_row(&list_box, "Enable Dock");
         settings.bind("manualhide", &switch, "active", SettingsBindFlags::DEFAULT | SettingsBindFlags::INVERT_BOOLEAN);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,22 +325,6 @@ fn dock_options<C: ContainerExt>(container: &C) {
     if let Some(settings) = settings::new_checked("org.gnome.shell.extensions.dash-to-dock") {
         let list_box = settings_list_box(container, "Dock Options");
 
-        // TODO: Use `bind_with_mapping` when gtk-rs version with that is released
-        let combo = combo_row(&list_box, "Show Dock on Display", "Primary Display", &[
-            "Primary Display",
-            "All Displays",
-        ]);
-        let id = if settings.get_boolean("multi-monitor") {
-            "All Displays"
-        } else {
-            "Primary Display"
-        };
-        combo.set_active_id(Some(id));
-        combo.connect_changed(clone!(@strong settings => move |combo| {
-            let all_displays = combo.get_active_id().map_or(false, |x| x == "All Displays" );
-            settings.set_boolean("multi-monitor", all_displays).unwrap();
-        }));
-
         let switch = switch_row(&list_box, "Extend dock to the edges of the screen");
         settings.bind("extend-height", &switch, "active", SettingsBindFlags::DEFAULT);
 
@@ -460,6 +444,21 @@ fn dock_visibility<C: ContainerExt>(container: &C) {
             settings.unblock_signal(&handler_id);
         }));
 
+        // TODO: Use `bind_with_mapping` when gtk-rs version with that is released
+        let combo = combo_row(&list_box, "Show Dock on Display", "Primary Display", &[
+            "Primary Display",
+            "All Displays",
+        ]);
+        let id = if settings.get_boolean("multi-monitor") {
+            "All Displays"
+        } else {
+            "Primary Display"
+        };
+        combo.set_active_id(Some(id));
+        combo.connect_changed(clone!(@strong settings => move |combo| {
+            let all_displays = combo.get_active_id().map_or(false, |x| x == "All Displays" );
+            settings.set_boolean("multi-monitor", all_displays).unwrap();
+        }));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,8 @@ fn main() {
                 .application(app)
                 .icon_name("pop-desktop-widget")
                 .window_position(gtk::WindowPosition::Center)
+                .default_height(600)
+                .default_width(800)
                 .build();
             ..set_titlebar(Some(&headerbar));
             ..add(&stack);


### PR DESCRIPTION
Fixes https://github.com/pop-os/desktop-widget/issues/16.

Also makes "Enable Dock" control the sensitivity of the other dock options. And sets the default window size for the binary target (only used for debugging).