### PR TITLE
Fix crash on dock option change if empty favorites

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ fn dock_options<C: ContainerExt>(container: &C) {
                 } else if index.is_none() {
                     // Insert at `pos`, or before first non-cosmic favorite
                     let pos = pos.min(
-                        favorites[..2]
+                        favorites
                             .iter()
                             .position(|x| {
                                 ![
@@ -385,7 +385,7 @@ fn dock_options<C: ContainerExt>(container: &C) {
                                 ]
                                 .contains(x)
                             })
-                            .unwrap_or(2),
+                            .unwrap_or(0),
                     );
                     favorites.insert(pos, desktop);
                 }


### PR DESCRIPTION
If no favorites have been set in the dock and any of the "Show X Icon in Dock" options are triggered, a crash will occur. 

```
Jun 29 23:13:56 pop-os gnome-control-center.desktop[164168]: thread '<unnamed>' panicked at 'range end index 2 out of range for slice of length 0', src/lib.rs:378:25
Jun 29 23:13:56 pop-os gnome-control-center.desktop[164168]: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Jun 29 23:13:56 pop-os gnome-control-center.desktop[164168]: fatal runtime error: failed to initiate panic, error 5
```