### PR TITLE
Add NoDisplay=true to Settings page shortcuts

### DIFF
--- a/data/gnome-background-panel-appearance.desktop
+++ b/data/gnome-background-panel-appearance.desktop
@@ -6,6 +6,7 @@ Exec=env POP_DESKTOP_PAGE=appearance gnome-control-center background
 Icon=preferences-desktop-wallpaper
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalizationSettings;
 OnlyShowIn=GNOME;

--- a/data/gnome-background-panel-cosmic.desktop
+++ b/data/gnome-background-panel-cosmic.desktop
@@ -6,6 +6,7 @@ Exec=env POP_DESKTOP_PAGE=main gnome-control-center background
 Icon=preferences-desktop-wallpaper
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalizationSettings;
 OnlyShowIn=GNOME;

--- a/data/gnome-background-panel-dock.desktop
+++ b/data/gnome-background-panel-dock.desktop
@@ -6,6 +6,7 @@ Exec=env POP_DESKTOP_PAGE=dock gnome-control-center background
 Icon=preferences-desktop-wallpaper
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalizationSettings;
 OnlyShowIn=GNOME;

--- a/data/gnome-background-panel-workspaces.desktop
+++ b/data/gnome-background-panel-workspaces.desktop
@@ -6,6 +6,7 @@ Exec=env POP_DESKTOP_PAGE=workspaces gnome-control-center background
 Icon=preferences-desktop-wallpaper
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalizationSettings;
 OnlyShowIn=GNOME;


### PR DESCRIPTION
Fixes https://github.com/pop-os/desktop-widget/issues/37.

I added the new line in the same place GNOME's included `gnome-background-panel.desktop` file puts it.