### PR TITLE
Make translations show up in GNOME Initial Setup

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -29,6 +29,8 @@ pub extern "C" fn pop_desktop_widget_gis_dock_page(header: *mut GtkWidget) -> *m
     unsafe {
         gtk::set_initialized();
     }
+    
+    localize();
 
     let header = unsafe { gtk::Widget::from_glib_none(header) };
     pop_desktop_widget::gis::dock::page(&header).to_glib_full()
@@ -44,6 +46,8 @@ pub extern "C" fn pop_desktop_widget_gis_extensions_page(header: *mut GtkWidget)
     unsafe {
         gtk::set_initialized();
     }
+    
+    localize();
 
     let header = unsafe { gtk::Widget::from_glib_none(header) };
     pop_desktop_widget::gis::extensions::page(&header).to_glib_full()
@@ -59,6 +63,8 @@ pub extern "C" fn pop_desktop_widget_gis_gestures_page(header: *mut GtkWidget) -
     unsafe {
         gtk::set_initialized();
     }
+    
+    localize();
 
     let header = unsafe { gtk::Widget::from_glib_none(header) };
     pop_desktop_widget::gis::gestures::page(&header).to_glib_full()
@@ -74,6 +80,8 @@ pub extern "C" fn pop_desktop_widget_gis_launcher_page(header: *mut GtkWidget) -
     unsafe {
         gtk::set_initialized();
     }
+    
+    localize();
 
     let header = unsafe { gtk::Widget::from_glib_none(header) };
     pop_desktop_widget::gis::launcher::page(&header).to_glib_full()
@@ -89,6 +97,8 @@ pub extern "C" fn pop_desktop_widget_gis_panel_page(header: *mut GtkWidget) -> *
     unsafe {
         gtk::set_initialized();
     }
+    
+    localize();
 
     let header = unsafe { gtk::Widget::from_glib_none(header) };
     pop_desktop_widget::gis::panel::page(&header).to_glib_full()

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -38,6 +38,8 @@ pub extern "C" fn pop_desktop_widget_gis_dock_page(header: *mut GtkWidget) -> *m
 
 #[no_mangle]
 pub extern "C" fn pop_desktop_widget_gis_dock_title() -> *mut libc::c_char {
+    localize();
+
     string_create(pop_desktop_widget::gis::dock::title())
 }
 


### PR DESCRIPTION
Fixes https://github.com/pop-os/desktop-widget/issues/54 by initializing localization when creating GIS pages. I also needed to initialize when creating the dock page title, although other page titles didn't need this done separately.

![Captura de tela de 2021-08-12 09-18-27](https://user-images.githubusercontent.com/7199422/129222948-308663a5-8d2b-46d2-be8b-3c0b97f93db5.png)
![Bildschirmfoto von 2021-08-12 09-17-31](https://user-images.githubusercontent.com/7199422/129222952-44e571bb-9e53-4738-bb7a-be3a185b4842.png)
