### PR TITLE
Add dropdown for dock icon click action

### DIFF
--- a/i18n/en/pop_desktop_widget.ftl
+++ b/i18n/en/pop_desktop_widget.ftl
@@ -4,6 +4,8 @@ action-launcher = Launcher
 action-launcher-description = Pressing the Super key opens the Launcher
 action-workspaces = Workspaces
 action-workspaces-description = Pressing the Super key opens the Window and Workspaces Overview
+click-action-cycle = Launch or Cycle Windows
+click-action-minimize = Launch or Minimize Windows
 disabled-super-warning =
   Super key override was disabled via advanced settings.
    • Super will open Workspaces unless behavior is specified by other extensions.
@@ -21,6 +23,7 @@ dock-always-hide = Always hide
 dock-always-hide-description = Dock always hides unless actively being revealed by the mouse
 dock-always-visible = Always visible
 dock-applications = Show Applications Icon in Dock
+dock-click-action = Icon Click Action
 dock-disable = No dock
 dock-dynamic = Dock doesn't extend to edges
 dock-enable = Enable Dock

--- a/i18n/en/pop_desktop_widget.ftl
+++ b/i18n/en/pop_desktop_widget.ftl
@@ -6,6 +6,7 @@ action-workspaces = Workspaces
 action-workspaces-description = Pressing the Super key opens the Window and Workspaces Overview
 click-action-cycle = Launch or Cycle Windows
 click-action-minimize = Launch or Minimize Windows
+click-action-minimize-or-previews = Launch, Minimize, or Preview Windows
 disabled-super-warning =
   Super key override was disabled via advanced settings.
    • Super will open Workspaces unless behavior is specified by other extensions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,6 +524,34 @@ fn dock_options<C: ContainerExt>(container: &C) {
 
         let switch = switch_row(&list_box, &fl!("dock-mounted-drives"));
         settings.bind("show-mounts", &switch, "active", SettingsBindFlags::DEFAULT);
+
+        let cycle_windows = &fl!("click-action-cycle");
+        let minimize = &fl!("click-action-minimize");
+        fn map_click_action_selection(selection: i32) -> &'static str {
+            return match selection {
+                0 => "cycle-windows",
+                1 => "minimize",
+                _ => "cycle-windows"
+            };
+        }
+        fn map_click_action_setting(setting: &str) -> u32 {
+            return match setting {
+                "cycle-windows" => 0,
+                "minimize" => 1,
+                _ => 0
+            }
+        }
+        cascade! {
+            combo_row(&list_box, &fl!("dock-click-action"), cycle_windows, &[
+                cycle_windows,
+                minimize
+            ]);
+            ..set_active(Some(map_click_action_setting(&settings.get_string("click-action").unwrap())));
+            ..connect_changed(clone!(@strong settings => move |combo| {
+                let click_action_selection = combo.get_active().unwrap_or(0) as i32;
+                settings.set_string("click-action", map_click_action_selection(click_action_selection)).unwrap();
+            }));
+        };
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,10 +527,12 @@ fn dock_options<C: ContainerExt>(container: &C) {
 
         let cycle_windows = &fl!("click-action-cycle");
         let minimize = &fl!("click-action-minimize");
+        let minimize_or_previews = &fl!("click-action-minimize-or-previews");
         fn map_click_action_selection(selection: i32) -> &'static str {
             return match selection {
                 0 => "cycle-windows",
                 1 => "minimize",
+                2 => "minimize-or-previews",
                 _ => "cycle-windows"
             };
         }
@@ -538,13 +540,15 @@ fn dock_options<C: ContainerExt>(container: &C) {
             return match setting {
                 "cycle-windows" => 0,
                 "minimize" => 1,
+                "minimize-or-previews" => 2,
                 _ => 0
             }
         }
         cascade! {
             combo_row(&list_box, &fl!("dock-click-action"), cycle_windows, &[
                 cycle_windows,
-                minimize
+                minimize,
+                minimize_or_previews
             ]);
             ..set_active(Some(map_click_action_setting(&settings.get_string("click-action").unwrap())));
             ..connect_changed(clone!(@strong settings => move |combo| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,9 +525,6 @@ fn dock_options<C: ContainerExt>(container: &C) {
         let switch = switch_row(&list_box, &fl!("dock-mounted-drives"));
         settings.bind("show-mounts", &switch, "active", SettingsBindFlags::DEFAULT);
 
-        let cycle_windows = &fl!("click-action-cycle");
-        let minimize = &fl!("click-action-minimize");
-        let minimize_or_previews = &fl!("click-action-minimize-or-previews");
         fn map_click_action_selection(selection: i32) -> &'static str {
             return match selection {
                 0 => "cycle-windows",
@@ -544,6 +541,9 @@ fn dock_options<C: ContainerExt>(container: &C) {
                 _ => 0
             }
         }
+        let cycle_windows = &fl!("click-action-cycle");
+        let minimize = &fl!("click-action-minimize");
+        let minimize_or_previews = &fl!("click-action-minimize-or-previews");
         cascade! {
             combo_row(&list_box, &fl!("dock-click-action"), cycle_windows, &[
                 cycle_windows,


### PR DESCRIPTION
Closes https://github.com/pop-os/cosmic-dock/issues/54.

Because we're not showing all of the dash-to-dock options, the dropdown index does not correspond to the gsetting index, so I needed to convert between them. I'm open to suggestions if there's a better way to do this.

Marking as draft for now because I'd like to see if we can include `minimize-or-previews` instead of/in addition to `minimize`. The `minimize` functionality of minimizing/restoring all of an app's windows at once doesn't seem very useful.