### PR TITLE
i18n(pl-PL): Add Polish translation

### DIFF
--- a/i18n/pl/pop_desktop_widget.ftl
+++ b/i18n/pl/pop_desktop_widget.ftl
@@ -1,0 +1,102 @@
+action-applications = Programy
+action-applications-description = Wciśnięcie guzika Super otwiera przegląd programów
+action-launcher = Panel startowy
+action-launcher-description = Wciśnięcie guzika Super otwiera panel startowy
+action-workspaces = Obszary robocze
+action-workspaces-description = Wciśnięcie guzika Super otwiera przegląd okien i obszarów roboczych
+click-action-cycle = Uruchom lub przełączaj okna
+click-action-minimize = Uruchom lub zminimalizuj okna
+click-action-minimize-or-previews = Uruchom, zminimalizuj lub podejrzyj okna
+disabled-super-warning =
+   Nadpisywanie zachowania guzika Super zostało wyłączone w zaawansowanych ustawieniach.
+   • Guzik Super otworzy obszary robocze chyba, że zachowanie zostało określone przez inne rozszerzenia.
+   • Wybranie jakieś opcji poniżej ponownie włączy nadpisywanie.
+
+date-combo = Pozycja daty, godziny i powiadomień
+date-combo-center = Środek
+date-combo-left = Lewa
+date-combo-right = Prawa
+
+display-all = Wszystkie ekrany
+display-primary = Ekran główny
+
+dock-always-hide = Zawsze ukrywaj
+dock-always-hide-description = Dok zawsze jest ukrywany chyba, że zostanie odkryty przez kursor myszy
+dock-always-visible = Zawsze widoczny
+dock-applications = Pokaż ikonę Programy w doku
+dock-click-action = Czynność po wciśnięciu ikony
+dock-disable = Bez doka
+dock-dynamic = Dok nie rozszerza się do krawędzi
+dock-enable = Włącz dok
+dock-extend = Rozszerz dok do krawędzi ekranu
+dock-extends = Dok rozszerza się do krawędzi
+dock-intelligently-hide = Inteligentnie ukrywaj
+dock-intelligently-hide-description = Dok jest ukrywany gdy dowolne okno nakłada się z powierzchnią doka
+dock-launcher = Pokaż ikonę panelu startowego w doku
+dock-mounted-drives = Pokaż zamontowane napędy
+dock-options = Ustawienia doka
+dock-size = Rozmiar doka
+dock-position = Pozycja na pulpicie
+dock-show-on-display = Pokaż dok na ekranie
+dock-visibility = Widoczność doka
+dock-workspaces = Pokaż ikonę Obszary robocze w doku
+
+gis-dock-description = Wygląd doka, jego rozmiar i pozycja może być zmieniona w dowolnym czasie ustawienia.
+gis-dock-header = Kontynuuj konfiguracje pulpitu przez wybranie preferowanego układu.
+gis-dock-title = Witaj w Pop!_OS
+
+gis-extensions-label1 = Ręcznie zainstalowane rozszerzenia powłoki GNOME są wyłączone by zapewnić rzetelne aktualizacje. Rozszerzenia zazwyczaj nie są testowane jako część Pop!_OS i mogą powodować problemy. Możesz je pojedynczo włączyć ponownie by zapewnić kompatybilność każdego z nich. By to zrobić, zainstaluj je ponownie z {$url}, lub przywróć je z katalogu kopii zapasowej.
+
+ Twoje rozszerzenia powłoki GNOME zostały przeniesione z:
+gis-extensions-label2 = Do tego folderu kopii zapasowej:
+gis-extensions-title = Aktualizacja rozszerzeń powłoki GNOME
+
+gis-gestures-description = Przesuń czterema palcami w lewo by otworzyć obszary robocze i przegląd okien, czterema palcami w prawo by otworzyć programy i czterema palcami w górę lub w dół by przełączać się między obszarami roboczymi. Przesuń trzema palcami by przełączać się między oknami.
+gis-gestures-title = Używaj gestów do łatwiejszej nawigacji
+
+gis-launcher-description = Wciśnij guzik Super lub użyj ikony w doku by wyświetlić pole wyszukiwania w panelu startowym. Użyj klawiszy strzałek by szybko przełączać się między oknami lub wpisać nazwę programu do uruchomienia. Panel startowy sprawia, że nawigacja jest szybsza i płynniejsza.
+gis-launcher-notice = Konfiguracja guzika Super może być zmieniona w dowolnym czasie w ustawieniach.
+gis-launcher-title = Otwieraj i przełączaj programy z panelu startowego
+
+gis-panel-notice = Konfiguracja górnego paska może być zmieniona w dowolnym czasie w ustawieniach.
+gis-panel-title = Konfiguracja górnego paska
+
+hot-corner = Aktywny róg
+hot-corner-description = Włącz lewy-górny aktywny róg dla obszarów roboczych
+
+multi-monitor-behavior = Zachowanie wielu monitorów
+
+page-appearance = Wygląd
+page-dock = Dok
+page-main = Ogólne
+page-workspaces = Obszary robocze
+
+position-bottom = Na dole ekranu
+position-left = Po lewej stronie
+position-right = Po prawej stronie
+
+show-applications-button = Pokaż guzik Programy
+show-maximize-button = Pokaż guzik maksymalizuj
+show-minimize-button = Pokaż guzik minimalizuj
+show-workspaces-button = Pokaż guzik Obszary robocze
+
+size-custom = Własny rozmiar
+size-large = Duży
+size-medium = Średni
+size-small = Mały
+
+super-key-action = Czynność guzika Super
+
+top-bar = Górny pasek
+
+window-controls = Przyciski na pasku tytułu
+
+workspace-picker-position = Umiejscowienie panelu wyboru obszarów roboczych
+
+workspaces-amount = Liczba obszarów roboczych
+workspaces-dynamic = Dynamiczne obszary robocze
+workspaces-dynamic-description = Automatycznie usuwa puste obszary robocze.
+workspaces-fixed = Stała liczba obszarów roboczych
+workspaces-fixed-description = Podaj liczbę obszarów roboczych
+workspaces-primary = Obszary robocze tylko na głównym ekranie
+workspaces-span-displays = Obszary robocze na wszystkich ekranach


### PR DESCRIPTION
I am not a translator. As matter of fact, I prefer using English in computers. I made the translation based on context I found in the system ( https://github.com/pop-os/pop/issues/1975 ), though I haven't found some of these phrases anywhere. However, to ensure consistency with existing translations, I looked up to Fedora 35's GNOME 41 translations. Notable mentions:
* Dock = Dok
* Workspace = Obszar roboczy
* Top Bar = Górny pasek
* Hot Corner = Aktywny róg ("active corner")
* Applications = Programy ("programs", though "applications" => "aplikacje" is mostly used in phones)
* Workspaces Span Displays - Unsure what it is exactly, neither I managed to test it on a virtual machine. GNOME 41 has `Workspaces on all displays` = "Obszary robocze na wszystkich ekranach", so I went with that. If this thing works differently in PopOS, please show me how it works for proper translation.
![gnome41workspaces](https://user-images.githubusercontent.com/32642697/140659674-05e3a9eb-284a-4277-a6b8-429069df7db5.png)
* Launcher - I have not found such term being used. I am not aware of direct translation either, so as far I know it either goes untranslated or gets changed to something like "Panel startowy" ("start panel"). First I went with untranslated, but eventually decided to go with the "start panel".

I am also neither Rust or Linux DE developer. This is the first time I contribute to something related to both of these. One time I tried to run this on a virtual machine, I quickly found myself lacking some dependencies. As such, this contribution is untested.

Lastly, I am aware that [Project Fluent](https://projectfluent.org) is used. Never used it myself, so I am uncertain of how it works exactly. To my understanding after quick review - there are no magic keywords, just variables and switch-case like behavior. Let's take the dock's size translation as example:
```
size-large = Duży
size-medium = Średni
size-small = Mały
```
This was translated in  _masculine_ context, as "dok" reads like it's male. However, if you ever wished to reuse the translation for fonts, which are _feminine_, they would be as following: **duża**, **średnia**, **mała**. Third (undefined?) for would likely be: **duże**, **średnie**, **małe**.

Other example:
```
date-combo-center = Środek
date-combo-left = Lewa
date-combo-right = Prawa 
```
For date **position** this is good proper translation, like so: "left side" = "**lewa** strona". However, "go to left" would be "idź w **lewo**".