### PR TITLE
feat: C API for creating each panel seperately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "pop-desktop-widget"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "cascade",
  "fomat-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pop-desktop-widget"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Michael Aaron Murphy <mmstick@pm.me>"]
 description = "GTK desktop settings widget for Pop!_OS"
 edition = "2018"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-desktop-widget (0.2.0) impish; urgency=medium
+
+  * Provide API to create each settings panel separately
+
+ -- Ian Douglas Scott <idscott@system76.com>  Mon, 28 Feb 2022 14:34:07 -0800
+
 pop-desktop-widget (0.1.0) groovy; urgency=medium
 
   * Initial release

--- a/ffi/pop_desktop_widget.h
+++ b/ffi/pop_desktop_widget.h
@@ -44,3 +44,11 @@ void pop_desktop_widget_localize ();
 
 /** Frees strings created by this library */
 void pop_desktop_widget_string_free (char *string);
+
+GtkWidget* pop_desktop_widget_gcc_main_page (void);
+
+GtkWidget* pop_desktop_widget_gcc_appearance_page (void);
+
+GtkWidget* pop_desktop_widget_gcc_dock_page (void);
+
+GtkWidget* pop_desktop_widget_gcc_workspaces_page (void);

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,10 +1,11 @@
+use glib::Cast;
 use glib::translate::{FromGlibPtrNone, ToGlibPtr};
+use gtk::prelude::*;
 use gtk_sys::GtkWidget;
 use pop_desktop_widget::PopDesktopWidget as RustWidget;
 use pop_desktop_widget::localize;
 use std::ffi::CString;
 
-#[no_mangle]
 pub struct PopDesktopWidget;
 
 #[no_mangle]
@@ -124,4 +125,44 @@ fn string_free(string: *mut libc::c_char) {
             CString::from_raw(string);
         }
     }
+}
+
+#[no_mangle]
+pub extern "C" fn pop_desktop_widget_gcc_main_page() -> *mut GtkWidget {
+    unsafe {
+        gtk::set_initialized();
+    }
+    let widget = pop_desktop_widget::main_page();
+    widget.show_all();
+    widget.upcast::<gtk::Widget>().to_glib_full()
+}
+
+#[no_mangle]
+pub extern "C" fn pop_desktop_widget_gcc_appearance_page() -> *mut GtkWidget {
+    unsafe {
+        gtk::set_initialized();
+    }
+    let widget = pop_desktop_widget::appearance_page();
+    widget.show_all();
+    widget.upcast::<gtk::Widget>().to_glib_full()
+}
+
+#[no_mangle]
+pub extern "C" fn pop_desktop_widget_gcc_dock_page() -> *mut GtkWidget {
+    unsafe {
+        gtk::set_initialized();
+    }
+    let widget = pop_desktop_widget::dock_page();
+    widget.show_all();
+    widget.upcast::<gtk::Widget>().to_glib_full()
+}
+
+#[no_mangle]
+pub extern "C" fn pop_desktop_widget_gcc_workspaces_page() -> *mut GtkWidget {
+    unsafe {
+        gtk::set_initialized();
+    }
+    let widget = pop_desktop_widget::workspaces_page();
+    widget.show_all();
+    widget.upcast::<gtk::Widget>().to_glib_full()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,7 @@ fn window_controls<C: ContainerExt>(container: &C) {
     }
 }
 
-fn main_page() -> gtk::Box {
+pub fn main_page() -> gtk::Box {
     let page = settings_vbox();
 
     super_key(&page);
@@ -371,7 +371,7 @@ fn main_page() -> gtk::Box {
     page
 }
 
-fn appearance_page() -> gtk::Box {
+pub fn appearance_page() -> gtk::Box {
     let page = settings_vbox();
 
     let theme_switcher = PopThemeSwitcher::new();
@@ -697,7 +697,7 @@ fn dock_position<C: ContainerExt>(container: &C) {
     }
 }
 
-fn dock_page() -> gtk::Box {
+pub fn dock_page() -> gtk::Box {
     let page = settings_vbox();
 
     let list_box = framed_list_box();
@@ -802,7 +802,7 @@ fn workspaces_position<C: ContainerExt>(container: &C) {
     }
 }
 
-fn workspaces_page() -> gtk::Box {
+pub fn workspaces_page() -> gtk::Box {
     let page = settings_vbox();
 
     let list_box = cascade! {


### PR DESCRIPTION
Will allow Gnome Control Center to use proper subpanels here.

Bumped version and updated changelog.

Should work with existing Gnome Control Center with no visible change in behavior.