### PR TITLE
Make dock size header translatable

### DIFF
--- a/i18n/en/pop_desktop_widget.ftl
+++ b/i18n/en/pop_desktop_widget.ftl
@@ -34,6 +34,7 @@ dock-mounted-drives = Show Mounted Drives
 dock-options = Dock Options
 dock-position = Position on the Desktop
 dock-show-on-display = Show Dock on Display
+dock-size = Dock Size
 dock-visibility = Dock Visibility
 dock-workspaces = Show Workspaces Icon in Dock
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,7 +641,7 @@ fn dock_visibility<C: ContainerExt>(container: &C) {
 
 fn dock_size<C: ContainerExt>(container: &C) {
     if let Some(settings) = settings::new_checked("org.gnome.shell.extensions.dash-to-dock") {
-        let list_box = settings_list_box(container, "Dock Size");
+        let list_box = settings_list_box(container, &fl!("dock-size"));
 
         let mut description: String = [&fl!("size-small"), " (36px)"].concat();
         let radio_small = radio_row(&list_box, &description, None);


### PR DESCRIPTION
Fixes the untranslatable string pointed out in https://github.com/pop-os/desktop-widget/pull/82.