### PR TITLE
feat: Add option to only show open windows on the current workspace

### DIFF
--- a/i18n/en/pop_desktop_widget.ftl
+++ b/i18n/en/pop_desktop_widget.ftl
@@ -29,6 +29,7 @@ dock-extend = Extend dock to the edges of the screen
 dock-extends = Dock extends to edges
 dock-intelligently-hide = Intelligently hide
 dock-intelligently-hide-description = Dock hides when any window overlaps the dock area
+dock-isolate-workspaces = Only show windows on the current workspace
 dock-launcher = Show Launcher Icon in Dock
 dock-mounted-drives = Show Mounted Drives
 dock-options = Dock Options

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,6 +501,9 @@ fn dock_options<C: ContainerExt>(container: &C) {
                 settings.set_string("click-action", map_click_action_selection(click_action_selection)).unwrap();
             }));
         };
+
+        let switch = switch_row(&list_box, &fl!("dock-isolate-workspaces"));
+        settings.bind("isolate-workspaces", &switch, "active").build();
     }
 }
 


### PR DESCRIPTION
This exposes in the GUI an existing dock option to only show open app windows that are located on the current workspace. As a mouse-centric, non-tiling user, when I'm working on multiple projects or tasks, I generally have their respective windows separated out by workspace and I often use the dock to switch between overlapping windows. However, without this option, I often have to sift through many open windows that are on other workspaces and are unrelated to the current task. This option makes workspaces (and COSMIC by extension) more useful to users with this workflow.

An example of how this looks/works:

https://user-images.githubusercontent.com/7199422/194153159-9b842c6f-3f27-43b7-8a2f-1a7bab98e499.mp4

The copy, position, etc. of the option can be adjusted if needed.