### PR TITLE
i18n(da): Fix Danish translation

### DIFF
--- a/i18n/da/pop_desktop_widget.ftl
+++ b/i18n/da/pop_desktop_widget.ftl
@@ -1,105 +1,105 @@
-action-applications = Applikationer
-action-applications-description = At klikke på Super tasten åbner Applkations Oversigten
+action-applications = Programmer
+action-applications-description = Et tryk på Super tasten åbner Program Oversigten
 action-launcher = Launcher
-action-launcher-description = At klikke på Super tasten åbner Launcheren
-action-workspaces = Workspaces
-action-workspaces-description = At klikke på Super tasten åbner Vinduet og Workspaces Overviewet
+action-launcher-description = Et tryk på Super tasten åbner Launcheren
+action-workspaces = Arbejdsområder
+action-workspaces-description = Et tryk på Super tasten åbner Vindue- og Arbejdsområde Oversigten
 
-click-action-cycle = Start eller Cyklus Vinduer
-click-action-minimize = Start eller Minimer Vinduer
-click-action-minimize-or-previews = Start, Minimer, eller forhåndsvis Windows
+click-action-cycle = Åben eller Skift Mellem Vinduer
+click-action-minimize = Åben eller Minimer Vinduer
+click-action-minimize-or-previews = Åben, Minimer, eller Forhåndsvis Vinduer
 
 date-combo = Dato & Tid og Notifikations Position
-date-combo-center = Centrer
+date-combo-center = Midte
 date-combo-left = Venstre
 date-combo-right = Højre
 
 display-all = Alle Skærme
 display-primary = Primær Skærm
 
-dock-always-hide = Altid gem
-dock-always-hide-description = Dock gemmer altid medmindre den bliver aktivt afsløret af musen
-dock-always-visible = Altid synlig
-dock-applications = Vis Applikationer Ikon i Dock
-dock-click-action = Ikon Clik Aktion
+dock-always-hide = Skjul altid
+dock-always-hide-description = Dock er altid skjult medmindre den bliver aktiveret af musen
+dock-always-visible = Vis altid
+dock-applications = Vis Programmer Ikon i Dock
+dock-click-action = Ikon Klik Handling
 dock-disable = Ingen dock
 dock-dynamic = Dock forlænger ikke til kanterne
 dock-enable = Slå Dock til
 dock-extend = Forlæng dock til kanterne af skærmen
-dock-extends = Dock kanterne til kanterne
-dock-intelligently-hide = Gem intelligent
-dock-intelligently-hide-description = Dock gemmes når vinduer dækker dock området
-dock-launcher = Hvis Launcher Ikon i Dock
-dock-mounted-drives = Hvis Monterede Drev
+dock-extends = Dock forlænger til kanterne
+dock-intelligently-hide = Skjul intelligent
+dock-intelligently-hide-description = Dock skjules når vinduer dækker dock området
+dock-launcher = Vis Launcher Ikon i Dock
+dock-mounted-drives = Vis Monterede Drev
 dock-options = Dock Indstillinger
-dock-position = Position på hjemmeskærmen
-dock-alignment = Dock and Ikon Tilpasning på skærmen
-dock-show-on-display = Hvis Docken på Skærmen
+dock-position = Position på Skrivebordet
+dock-alignment = Dock og Ikon Tilpasning på Skærmen
+dock-show-on-display = Vis Dock på Skærm
 dock-size = Dock Størrelse
 dock-visibility = Dock Synlighed
-dock-workspaces = Hvis Workspaces Ikon i Docken
+dock-workspaces = Vis Arbejdsområder Ikon i Dock
 
-gis-dock-description = Dock udseende, dens Størrelse, og position kan ændres når som helt fra Indstillinger appen.
-gis-dock-header = Forsæt desktop setup ved at vælge dig layout.
+gis-dock-description = Dockens udseende, størrelse, og position kan ændres når som helst fra Indstillinger programmet.
+gis-dock-header = Fortsæt skrivebords opsætningen ved at vælge dit foretrukne layout.
 gis-dock-title = Velkommen til Pop!_OS
 
-gis-extensions-label1 = Manuelt installerede GNOME Shell extensions er slået fra for at forsikre opdateringer er pålidelige. extensions er for det meste ikke som en del af Pop!_OS og kan skabe problemer. Du kan manuelt slå dem til igen en efter en for at forsikre kompatibilitet for hver extension. For at slå til dem, installer dem igen fra {$url}, eller slå dem til igen fra backup mappen.
+gis-extensions-label1 = Manuelt installerede GNOME Shell udvidelser er slået fra for at sikre at opdateringer er pålidelige. Udvidelserne er oftest ikke testet som en del af Pop!_OS og kan skabe problemer. Du kan manuelt aktivere dem igen, en ad gangen, for at sikre kompatibilitet med hver udvidelse. For at aktivere, skal du installere dem igen fra {$url}, eller gendanne dem fra backup mappen.
 
- Dine GNOME Shell extensions er blevet flyttet fra:
+ Dine GNOME Shell udvidelser er blevet flyttet fra:
 gis-extensions-label2 = Til denne backup mappe:
-gis-extensions-title = GNOME Shell Extensions Opdatering
+gis-extensions-title = GNOME Shell Udvidelser Opdatering
 
-gis-gestures-description = Swipe venstre med fire fingre for at åbne Workspaces og vindue oversigt, swipe til højre med fire fingre for at åbne Applikationer, og swipe op eller ned med fire finger for at skifte mellem workspaces. Swipe med tre finger for at skifte mellem vinduer.
-gis-gestures-title = Brug Gestures for lettere navigation
+gis-gestures-description = Swipe til venstre med fire fingre for at åbne Arbejdsområder- og vindue oversigt, swipe til højre med fire fingre for at åbne Programmer, og swipe op eller ned med fire fingre for at skifte mellem arbejdsområder. Swipe med tre fingre for at skifte mellem vinduer.
+gis-gestures-title = Brug fingerbevægelser for lettere navigation
 
-gis-launcher-description = Klik på Super Tasten eller brug et ikon i docken for at åbne skærm Launcher søge fældet. Brug pile tasterne hurtigt for at skifte mellem åbne vinduer eller skriv navnet af applikationen for at åbne den. Launcheren gør at navigatere skærmen hurtigere og mere flydende.
-gis-launcher-notice = Super tast konfiguration kan ændres når som helt fra Settings applikationen.
-gis-launcher-title = Åben og Skift Applikationer fra Launcheren
+gis-launcher-description = Tryk på Super Tasten eller brug et ikon i docken for at åbne Launcher søgefeltet. Brug piletasterne til hurtigt at skifte mellem åbne vinduer eller skriv navnet på programmet for at åbne det. Launcheren gør det hurtigere og mere flydende at navigere skrivebordet.
+gis-launcher-notice = Super tast handlingen kan ændres når som helst fra Indstillinger programmet.
+gis-launcher-title = Åben og Skift Programmer fra Launcheren
 
-gis-panel-notice = Top bar konfiguration kan ændres når som helt fra Settings applikationen.
-gis-panel-title = Konfigurer Top Baren
+gis-panel-notice = Indstillingerne for top bjælken kan ændres når som helst fra Indstillinger programmet.
+gis-panel-title = Indstil Top Bjælken
 
 hot-corner = Varmt Hjørne
-hot-corner-description = Slå top-venstre varmt hjørne for Workspaces til
+hot-corner-description = Aktiver varmt hjørne for Arbejdsområder øverst til venstre
 
 multi-monitor-behavior = Multi-skærms Opførsel
 
 page-appearance = Udseende
 page-dock = Dock
-page-main = Generalt
-page-workspaces = Workspaces
+page-main = Generelt
+page-workspaces = Arbejdsområder
 
 position-bottom = Bunden af skærmen
-position-left = På den venstre side
-position-right = På den højre side
+position-left = Langs den venstre side
+position-right = Langs den højre side
 
-alignment-center = Centrer
-alignment-start = Start
+alignment-center = Midte
+alignment-start = Begyndelse
 alignment-end = Ende
 
-show-applications-button = Hvis Applkations Knap
-show-maximize-button = Hvis Maximiser Knap
-show-minimize-button = Hvis Minimer Knap
-show-workspaces-button = Hvis Workspaces Knap
+show-applications-button = Vis Programmer Knap
+show-maximize-button = Vis Maksimer Knap
+show-minimize-button = Vis Minimer Knap
+show-workspaces-button = Vis Arbejdsområder Knap
 
 size-custom = Brugerdefineret Størrelse
 size-large = Stor
-size-medium = Medium
+size-medium = Mellem
 size-small = Lille
 
-super-key-action = Super Tast Aktion
+super-key-action = Super Tast Handling
 
-top-bar = Top Bar
+top-bar = Top Bjælke
 
 window-controls = Vindue Kontrolelementer
 
-workspace-picker-position = Placering af Workspace Udvælgeren
+workspace-picker-position = Placering af Arbejdsområde Vælgeren
 
-workspaces-amount = Number af Workspaces
-workspaces-dynamic = Dynamiske Workspaces
-workspaces-dynamic-description = Automatically Fjerne tomme workspaces.
-workspaces-fixed = Fast nummer af Workspaces
-workspaces-fixed-description = Specify et number af workspaces
-workspaces-primary = Workspaces på kun den Primary skærm
-workspaces-span-displays = Workspaces Span Skærme
+workspaces-amount = Antal Arbejdsområder
+workspaces-dynamic = Dynamiske Arbejdsområder
+workspaces-dynamic-description = Fjerner automatisk tomme arbejdsområder.
+workspaces-fixed = Fast Antal Arbejdsområder
+workspaces-fixed-description = Angiv et antal arbejdsområder
+workspaces-primary = Arbejdsområder Kun på den Primære Skærm
+workspaces-span-displays = Arbejdsområder Dækker Alle Skærme
 


### PR DESCRIPTION
The Danish translation is very bad. It has many misspelled words, sentences that are half English and Danish, sentences that do not make any sense, words that are used incorrectly, I could go on...

In this PR, 90% of the changes are objective improvements because the original sentence was not actually Danish. The last 10% are editorial changes were I have changed the sentence to, in my opinion, better describe the setting.